### PR TITLE
ZSH Tmux Compatibilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 files/.vim/bundle
+files/.vim/.netrwhist

--- a/files/.tmux.conf
+++ b/files/.tmux.conf
@@ -24,3 +24,5 @@ bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "reattach-to-user-n
 setw -g mode-keys vi
 
 setw -g default-terminal "screen-256color"
+
+set-option -g default-shell /usr/local/bin/zsh

--- a/files/.tmux.conf
+++ b/files/.tmux.conf
@@ -18,7 +18,7 @@ bind-key -T copy-mode-vi v send-keys -X begin-selection
 bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
 
 # Restoring clear screen
-# bind C-l send-keys 'C-l'
+bind C-l send-keys 'C-l'
 
 # Use vim keybindings in copy mode
 setw -g mode-keys vi

--- a/files/.vim/vimrc
+++ b/files/.vim/vimrc
@@ -34,7 +34,9 @@ Plugin 'VundleVim/Vundle.vim'
 " Keep Plugin commands between vundle#begin/end.
 " plugin on GitHub repo
 Plugin 'christoomey/vim-tmux-navigator'
-
+" Plugin 'benmills/vimux'
+" Plugin 'tpope/vim-dispatch'
+"
 " All of your Plugins must be added before the following line
 call vundle#end()            " required
 filetype plugin indent on    " load plugin indent files

--- a/files/.zshrc
+++ b/files/.zshrc
@@ -26,7 +26,7 @@ ZSH_THEME="blinks"
 # DISABLE_LS_COLORS="true"
 
 # Uncomment the following line to disable auto-setting terminal title.
-# DISABLE_AUTO_TITLE="true"
+DISABLE_AUTO_TITLE="true"
 
 # Uncomment the following line to enable command auto-correction.
 # ENABLE_CORRECTION="true"
@@ -88,3 +88,6 @@ source $HOME/.profile
 # Disable Shared History
 # unsetopt inc_append_history
 unsetopt share_history
+
+# Enable for loop splitting of strings
+setopt shwordsplit


### PR DESCRIPTION
### Changes

* Set `zsh` as default shell
* Disable auto title to keep window names
* Use `shwordsplit` to enable use of for x in 'a b c'
* misc.