### PR TITLE
Add python support

### DIFF
--- a/files/.ctags
+++ b/files/.ctags
@@ -1,0 +1,5 @@
+--python-kinds=-iv
+--exclude=.git
+--exclude=build
+--exclude=node_modules
+--exclude=\*.pyc

--- a/files/.gitignore_global
+++ b/files/.gitignore_global
@@ -1,3 +1,4 @@
 *.swp
 *.pid
 .DS_STORE
+tags

--- a/files/.vim/vimrc
+++ b/files/.vim/vimrc
@@ -36,7 +36,12 @@ Plugin 'christoomey/vim-tmux-navigator'
 " Plugin 'rust-lang/rust.vim'
 " Plugin 'tmhedberg/SimplyFold'
 " let g:SimplyFold_docstring_preview=1
+
+" Catch syntax / lint errors
+" :lopen shows detailed errors
+" :lnext goes to next error
 Plugin 'vim-syntastic/syntastic'
+
 Plugin 'vim-scripts/indentpython.vim'
 Plugin 'nvie/vim-flake8'
 " Plugin 'Valloric/YouCompleteMe'
@@ -75,14 +80,13 @@ colorscheme solarized
 let python_highlight_all=1
 " }}}
 
-" Syntax {{{
+" Plugin Options {{{
+
+" Syntastic
 let g:syntastic_python_checkers = ['flake8']
 let g:syntastic_python_flake8_args = '--ignore=E,W,F403'
-set statusline+=%#warningmsg#
-set statusline+=%{SyntasticStatuslineFlag()}
-set statusline+=%*
-let g:syntastic_always_populate_loc_list = 1
-let g:syntastic_auto_loc_list = 1
+let g:syntastic_always_populate_loc_list = 1  " Populate LOC by default (don't require :Errors)
+" let g:syntastic_auto_loc_list = 1             " Show detailed errors, or :lopen
 let g:syntastic_check_on_open = 1
 let g:syntastic_check_on_wq = 0
 " }}}

--- a/files/.vim/vimrc
+++ b/files/.vim/vimrc
@@ -41,9 +41,9 @@ Plugin 'christoomey/vim-tmux-navigator'
 " :lopen shows detailed errors
 " :lnext goes to next error
 Plugin 'vim-syntastic/syntastic'
+Plugin 'nvie/vim-flake8'
 
 Plugin 'vim-scripts/indentpython.vim'
-Plugin 'nvie/vim-flake8'
 " Plugin 'Valloric/YouCompleteMe'
 " let g:ycm_autoclose_preview_window_after_completion=1
 " map <leader>g  :YcmCompleter GoToDefinitionElseDeclaration<CR>

--- a/files/.vim/vimrc
+++ b/files/.vim/vimrc
@@ -220,7 +220,7 @@ augroup END
 " }}}
 
 " Language overrides {{{
-" python with virtualenv support
+" Enable python python with active virtualenv
 py << EOF
 import os
 import sys

--- a/files/.vim/vimrc
+++ b/files/.vim/vimrc
@@ -1,14 +1,10 @@
 " Heavy inspiration from: https://dougblack.io/words/a-good-vimrc.html
 
 " Plugins {{{
-" Valloric/YouCompleteMe
 " vim-syntastic/syntastic
 " surround
 " repeat
 " objtext
-" ag.vim  " Source searching!
-" open ag.vim
-" nnoremap <leader>a :Ag
 " gundo.vim  " Display undo tree in graphical form
 " ctrlp.vim  " Fuzzy file searching vs commandt.vim
 " CtrlP settings
@@ -38,6 +34,19 @@ Plugin 'VundleVim/Vundle.vim'
 Plugin 'christoomey/vim-tmux-navigator'
 " Plugin 'benmills/vimux'
 " Plugin 'tpope/vim-dispatch'
+" Plugin 'rust-lang/rust.vim'
+" Plugin 'tmhedberg/SimplyFold'
+" let g:SimplyFold_docstring_preview=1
+" Plugin 'vim-scripts/indentpython.vim'
+" Plugin 'Valloric/YouCompleteMe'
+" let g:ycm_autoclose_preview_window_after_completion=1
+" map <leader>g  :YcmCompleter GoToDefinitionElseDeclaration<CR>
+" Plugin 'vim-syntastic/syntastic'
+" Plugin 'nvie/vim-flake8'
+" Plugin 'jnurmine/Zenburn'
+" ag.vim  " Source searching!
+" open ag.vim
+" nnoremap <leader>a :Ag
 "
 " All of your Plugins must be added before the following line
 call vundle#end()            " required
@@ -62,12 +71,21 @@ syntax enable        " enable syntax processing
 let g:solarized_termcolors=256
 set background=dark
 colorscheme solarized
+
+" Python specific
+let python_highlight_all=1
+" }}}
+
+" Syntax {{{
+" let g:syntastic_python_checkers = ['flake8']
+" let g:syntastic_python_flake8_args = '--ignore=E,W,F403'
 " }}}
 
 " Whitespace {{{
 set tabstop=4        " number of visual spaces per TAB
 set softtabstop=4    " number of spaces in TAB when editing
 set expandtab        " tabs are spaces
+set fileformat=unix  " Unix file types
 " }}}
 
 " UI Config {{{
@@ -88,6 +106,7 @@ set mouse=a          " Enable dragging of splits
 set incsearch        " search as characters are entered
 set hlsearch         " highlight matches
 " turn off search highlighting
+" TODO: This stopped working on *nix
 nnoremap <leader><space> :nohlsearch<CR>
 " }}}
 
@@ -114,6 +133,7 @@ let g:netrw_list_hide.=',\(^\/\s\s\)\zs\.\S\+'
 " }}}
 
 " Shortcuts {{{
+" TODO: This doesn't work
 let mapleader=","       " leader is comma vs '\'
 " ;; is escape
 inoremap ;; <esc>
@@ -179,6 +199,9 @@ augroup configgroup
     autocmd FileType ruby setlocal softtabstop=2
     autocmd FileType ruby setlocal commentstring=#\ %s
     autocmd FileType python setlocal commentstring=#\ %s
+    autocmd FileType python setlocal shiftwidth=4
+    autocmd FileType python setlocal textwidth=79
+    autocmd FileType python setlocal autoindent
     autocmd BufEnter *.cls setlocal filetype=java
     autocmd BufEnter *.zsh-theme setlocal filetype=zsh
     autocmd BufEnter Makefile setlocal noexpandtab
@@ -187,6 +210,18 @@ augroup configgroup
     autocmd BufEnter *.sh setlocal shiftwidth=2
     autocmd BufEnter *.sh setlocal softtabstop=2
 augroup END
+" }}}
+
+" Language overrides {{{
+" python with virtualenv support
+py << EOF
+import os
+import sys
+if 'VIRTUAL_ENV' in os.environ:
+    project_base_dir = os.environ['VIRTUAL_ENV']
+    activate_this = os.path.join(project_base_dir, 'bin/activate_this.py')
+    execfile(activate_this, dict(__file__=activate_this))
+EOF
 " }}}
 
 " Backups {{{

--- a/files/.vim/vimrc
+++ b/files/.vim/vimrc
@@ -75,9 +75,6 @@ syntax enable        " enable syntax processing
 let g:solarized_termcolors=256
 set background=dark
 colorscheme solarized
-
-" Python specific
-let python_highlight_all=1
 " }}}
 
 " Plugin Options {{{

--- a/files/.vim/vimrc
+++ b/files/.vim/vimrc
@@ -158,6 +158,7 @@ nnoremap <c-l> <c-w>l
 nnoremap <CR> o<ESC>k
 " Configure ctags for tag jumping
 command! MakeTags !ctags -R .
+command! MakePTags !ctags -R . $(python -c "import os, sys; print(' '.join('{}'.format(d) for d in sys.path if os.path.isdir(d)))")
 
 " allows cursor change in tmux mode
 if exists('$TMUX')

--- a/files/.vim/vimrc
+++ b/files/.vim/vimrc
@@ -113,7 +113,6 @@ set mouse=a          " Enable dragging of splits
 set incsearch        " search as characters are entered
 set hlsearch         " highlight matches
 " turn off search highlighting
-" TODO: This stopped working on *nix
 nnoremap <leader><space> :nohlsearch<CR>
 " }}}
 

--- a/files/.vim/vimrc
+++ b/files/.vim/vimrc
@@ -1,7 +1,6 @@
 " Heavy inspiration from: https://dougblack.io/words/a-good-vimrc.html
 
 " Plugins {{{
-" vim-syntastic/syntastic
 " surround
 " repeat
 " objtext
@@ -37,12 +36,12 @@ Plugin 'christoomey/vim-tmux-navigator'
 " Plugin 'rust-lang/rust.vim'
 " Plugin 'tmhedberg/SimplyFold'
 " let g:SimplyFold_docstring_preview=1
-" Plugin 'vim-scripts/indentpython.vim'
+Plugin 'vim-syntastic/syntastic'
+Plugin 'vim-scripts/indentpython.vim'
+Plugin 'nvie/vim-flake8'
 " Plugin 'Valloric/YouCompleteMe'
 " let g:ycm_autoclose_preview_window_after_completion=1
 " map <leader>g  :YcmCompleter GoToDefinitionElseDeclaration<CR>
-" Plugin 'vim-syntastic/syntastic'
-" Plugin 'nvie/vim-flake8'
 " Plugin 'jnurmine/Zenburn'
 " ag.vim  " Source searching!
 " open ag.vim
@@ -77,8 +76,15 @@ let python_highlight_all=1
 " }}}
 
 " Syntax {{{
-" let g:syntastic_python_checkers = ['flake8']
-" let g:syntastic_python_flake8_args = '--ignore=E,W,F403'
+let g:syntastic_python_checkers = ['flake8']
+let g:syntastic_python_flake8_args = '--ignore=E,W,F403'
+set statusline+=%#warningmsg#
+set statusline+=%{SyntasticStatuslineFlag()}
+set statusline+=%*
+let g:syntastic_always_populate_loc_list = 1
+let g:syntastic_auto_loc_list = 1
+let g:syntastic_check_on_open = 1
+let g:syntastic_check_on_wq = 0
 " }}}
 
 " Whitespace {{{


### PR DESCRIPTION
Changes inspired by https://realpython.com/blog/python/vim-and-python-a-match-made-in-heaven/

### Changes:

- Syntax Checking via
  - Syntastic
  - flake8
- Python Indentation via
  - indentpython
- Set common `.py` file settings
- Enable `python` feature in vim to use virtualenv
- `MakePTags` to generate tags for python added

