### PR TITLE
Use SHELL correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ that made me reevaluate my configuration setup
 * [`.vimrc` setup](https://dougblack.io/words/a-good-vimrc.html)
 * [Mastering the Vim Language](https://www.youtube.com/watch?v=wlR5gYd6um0&list=LLR8PzB32EL-ldL7Vo_xPCQg&index=1)
 
+## How to Setup
+
+- You may need to configure your default shell to be `zsh`, to do so run:
+
+```
+chsh -s /bin/zsh
+```
+
 ## How to Update
 
 1. Run `sudo ./install_packages.sh` to install system packages

--- a/files/.tmux.conf
+++ b/files/.tmux.conf
@@ -25,7 +25,9 @@ setw -g mode-keys vi
 
 setw -g default-terminal "screen-256color"
 
-set-option -g default-shell /usr/local/bin/zsh
+set-option -g default-shell $SHELL
+# Mac OS: Enable pbcopy and pbpaste
+set -g default-command "reattach-to-user-namespace -l ${SHELL}"
 
 # Plugins
 


### PR DESCRIPTION
Use the shell variable to set the default shell

note that the instructions specify `/bin/zsh`, use whatever you find in `/etc/shells`